### PR TITLE
Params fix services.yml

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,5 +3,5 @@ parameters:
 
 services:
     scribe.clockwork:
-        class: %scribe.clockwork.class%
+        class: '%scribe.clockwork.class%'
         arguments: [ "@service_container" ]


### PR DESCRIPTION
Fixes the compatiblity issue with Symfony 4.4.

In YamlFileLoader.php line 694:
                                                                                                                                                           
  The file "/data/j1/vendor/scribe/clockwork-bundle/Scribe/ClockworkBundle/DependencyInjection/../Resources/config/services.yml" does not contain valid Y  
  AML: The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 6 (near "class: %scribe.clockwork.class%").   